### PR TITLE
Update GZDoom to version 4.1.1

### DIFF
--- a/io.github.FreeDM.yaml
+++ b/io.github.FreeDM.yaml
@@ -1,7 +1,7 @@
 app-id: io.github.FreeDM
 runtime: org.freedesktop.Platform
 sdk: org.freedesktop.Sdk
-runtime-version: '18.08'
+runtime-version: "18.08"
 command: gzdoom.sh
 rename-desktop-file: freedm.desktop
 rename-appdata-file: freedm.appdata.xml
@@ -51,12 +51,13 @@ modules:
   config-opts:
   - -DCMAKE_BUILD_TYPE=RelWithDebInfo
   - -DSEND_ANON_STATS=OFF
+  - -DCMAKE_CXX_FLAGS="-msse3" # Required when targeting 32-bit x86
   sources:
   - type: archive
-    url: https://github.com/coelckers/gzdoom/archive/g3.7.2.tar.gz
-    sha256: 5fb57c83b733d77688b5809b3bd64ab87f0976f4e81d3bbac0ea0785a24646cc
+    url: https://github.com/coelckers/gzdoom/archive/g4.1.1.tar.gz
+    sha256: 50ce34b48518fb8715d6e346ff3ac8d08fd24b34e764be88335810fa592fb84a
   - type: file
-    url: https://github.com/coelckers/gzdoom/raw/g3.7.2/soundfont/gzdoom.sf2
+    url: https://github.com/coelckers/gzdoom/raw/g4.1.1/soundfont/gzdoom.sf2
     sha256: fca3e514b635a21789d4224e84865d2954a2a914d46b64aa8219ddb565c44869
   - type: shell
     commands:
@@ -92,6 +93,8 @@ modules:
   - install -Dm 644 freedm.desktop -t /app/share/applications
   - install -Dm 644 freedm.appdata.xml -t /app/share/appdata
   - sed -e 's|</description>|<p>This package uses the GZDoom source port.</p></description>|' -i /app/share/appdata/freedm.appdata.xml
+  - sed -e 's|</component>|<releases><release version="0.11.3" date="2017-07-18"></release></releases></component>|' -i /app/share/appdata/freedm.appdata.xml
+  - sed -e 's|</component>|<content_rating type="oars-1.1"><content_attribute id="violence-bloodshed">intense</content_attribute></content_rating></component>|' -i /app/share/appdata/freedm.appdata.xml
   - install -Dm 644 freedm_title2-48x48.png /app/share/icons/hicolor/48x48/apps/freedm.png
   - install -Dm 644 freedm_title2-64x64.png /app/share/icons/hicolor/64x64/apps/freedm.png
   - install -Dm 644 freedm_title2-128x128.png /app/share/icons/hicolor/128x128/apps/freedm.png


### PR DESCRIPTION
This enforces SSE3 usage which is now required on 32-bit. This also adds release information and content rating to the AppStream metadata, which are now required by Flathub.

This closes #4 (upstream PR: https://github.com/freedoom/freedoom/pull/562).