### PR TITLE
Update the Freedesktop runtime to 19.08

### DIFF
--- a/io.github.FreeDM.yaml
+++ b/io.github.FreeDM.yaml
@@ -1,7 +1,7 @@
 app-id: io.github.FreeDM
 runtime: org.freedesktop.Platform
 sdk: org.freedesktop.Sdk
-runtime-version: "18.08"
+runtime-version: "19.08"
 command: gzdoom.sh
 rename-desktop-file: freedm.desktop
 rename-appdata-file: freedm.appdata.xml


### PR DESCRIPTION
This appears to make Vulkan support work in GZDoom (tested on NVIDIA).